### PR TITLE
Display interrupt to user

### DIFF
--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -343,10 +343,7 @@ if st.session_state.should_rerun:
                             st.success("Thank you for your detailed feedback!")
 
         except NodeInterrupt as e:
-            st.error(
-                "Tool authorization required. Please check your Arcade dashboard to authorize the tool."
-            )
-            st.error(f"Details: {str(e)}")
+            display_interrupt_details(e)
 
         except Exception as e:
             st.error(f"An error occurred while re-running: {str(e)}")
@@ -450,10 +447,19 @@ if prompt := st.chat_input("Ask me to analyze any webpage!"):
                             st.success("Thank you for your detailed feedback!")
 
         except NodeInterrupt as e:
-            st.error(
-                "Tool authorization required. Please check your Arcade dashboard to authorize the tool."
-            )
-            st.error(f"Details: {str(e)}")
+            display_interrupt_details(e)
 
         except Exception as e:
             st.error(f"An error occurred sending the request to the agent: {str(e)}")
+
+
+def display_interrupt_details(e: NodeInterrupt) -> None:
+    """Display interrupt details using st.write."""
+    interrupt_details = {
+        "Type": type(e).__name__,
+        "Message": str(e),
+        "Context": e.context if hasattr(e, "context") else "N/A",
+        "Timestamp": time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime()),
+        "Actions": e.actions if hasattr(e, "actions") else "N/A",
+    }
+    st.write("Interrupt details:", interrupt_details)


### PR DESCRIPTION
Fixes #1

Update `NodeInterrupt` exception handling to display interrupt details using `st.write`.

* Add `display_interrupt_details` function to display interrupt details.
* Update `NodeInterrupt` exception handling block to call `display_interrupt_details`.
* Include type of interrupt, message, context, timestamp, and actions in `display_interrupt_details` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hey-aw/arcade-tools-chat/pull/2?shareId=6b58d1c6-edd9-48cc-ba9e-356199b523d0).