### PR TITLE
Use callbacks to improve reliability of st.login and st.logout

### DIFF
--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -21,8 +21,9 @@ st.set_page_config(
 )
 
 # Check authentication
-if st.experimental_user.get("email") is None:
-    st.login()
+if not st.experimental_user.is_logged_in:
+    st.button("Log in with Google", on_click=st.login)
+    st.stop()
 
 # Add sidebar profile section
 with st.sidebar:
@@ -48,11 +49,11 @@ with st.sidebar:
             st.write(st.experimental_user)
 
         st.divider()
-        if st.button("Logout", use_container_width=True, icon=":material/logout:"):
-            st.logout()
+        if st.button("Log out", on_click=st.logout, use_container_width=True, icon=":material/logout:"):
+            st.stop()
     else:
         st.write("Please log in to continue")
-        st.login()
+        st.button("Log in with Google", on_click=st.login)
 
 
 manager = ArcadeToolManager()


### PR DESCRIPTION
Fixes #7

Add login and logout buttons with callbacks to improve user authentication flow.

* Add a login button using `st.button("Log in with Google", on_click=st.login)` if the user is not logged in.
* Add `st.stop()` after the login button to stop the script execution until the user logs in.
* Replace the direct call to `st.login()` with the login button.
* Modify the logout button to use `st.button("Log out", on_click=st.logout)` and add `st.stop()` after the logout button to redirect the user to the Sign In page after logout.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/eddo-ai/arcade-tools-chat/pull/8?shareId=52e70aa6-2467-45b9-b6f1-51e25e6f8f51).